### PR TITLE
Read only the first 65536 bytes of a file or a chunk

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import {Readable} from 'node:stream';
 import test from 'ava';
 import {readChunkSync} from 'read-chunk';
 import isProgressive from './index.js';
@@ -19,6 +20,15 @@ test('.stream()', async t => {
 	t.false(await isProgressive.stream(fs.createReadStream(getPath('baseline'))));
 	t.false(await isProgressive.stream(fs.createReadStream(getPath('kitten'))));
 	t.true(await isProgressive.stream(fs.createReadStream(getPath('kitten-progressive'))));
+});
+
+// Discovered in the tests for is-progressive-cli
+test('.stream() - the whole file', async t => {
+	t.true(await isProgressive.stream(Readable.from(fs.readFileSync(getPath('progressive')))));
+	t.true(await isProgressive.stream(Readable.from(fs.readFileSync(getPath('curious-exif')))));
+	t.false(await isProgressive.stream(Readable.from(fs.readFileSync(getPath('baseline')))));
+	t.false(await isProgressive.stream(Readable.from(fs.readFileSync(getPath('kitten')))));
+	t.true(await isProgressive.stream(Readable.from(fs.readFileSync(getPath('kitten-progressive')))));
 });
 
 test('.file()', async t => {


### PR DESCRIPTION
I went to update `is-progressive-cli` and one of the tests failed, but it wasn't entirely clear why it failed. One issue was that I used readableHighWaterMark, but that's not a guarantee that the chunk will be smaller.

However, even fixing that, there was something wrong with doing `buffer.set(data, 1)` on a readable stream from a buffer. To work around it, I used `subarray` on the chunk.

I also realized that we want to return `false` earlier if the number of bytes read is >= `MAX_BUFFER`. No need to parse the entire file or stream.
